### PR TITLE
Fix: Improve Label Alignment and Spacing in Profile View (Issue #4973)

### DIFF
--- a/app/web/components/LabelAndText.tsx
+++ b/app/web/components/LabelAndText.tsx
@@ -12,6 +12,7 @@ const useStyles = makeStyles((theme) => ({
   root: {
     display: "flex",
     marginTop: theme.spacing(0.5),
+    alignItems: "flex-start", // Ensures the label aligns with the top of multi-line text
   },
   flexItem: {
     flex: "1 1 50%",

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -107,6 +107,11 @@ const useStyles = makeStyles((theme) => ({
     margin: theme.spacing(0.5),
     alignSelf: "center",
   },
+  container: {
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+  },
 }));
 
 const AgeAndGenderRenderer = ({ user }: Props) => {
@@ -180,13 +185,7 @@ const AgeAndGenderRenderer = ({ user }: Props) => {
     }
   };
   return (
-    <div
-      style={{
-        display: "flex",
-        flexWrap: "wrap",
-        alignItems: "center",
-      }}
-    >
+    <div className={useStyles().container}>
       <span>{age}</span>
       {getBirthdateVerificationIcon(birthdateVerificationStatus)}
       <span>/&nbsp;</span>

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -180,13 +180,20 @@ const AgeAndGenderRenderer = ({ user }: Props) => {
     }
   };
   return (
-    <>
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+      }}
+    >
       <span>{age}</span>
-      {getBirthdateVerificationIcon(birthdateVerificationStatus)} /&nbsp;
+      {getBirthdateVerificationIcon(birthdateVerificationStatus)}
+      <span>/</span>
       <span>{gender}</span>
       {getGenderVerificationIcon(genderVerificationStatus)}
-      <span> {pronouns && ` (${pronouns})`}</span>
-    </>
+      {pronouns && <span>({pronouns})</span>}
+    </div>
   );
 };
 
@@ -248,3 +255,4 @@ export const RemainingAboutLabels = ({ user }: Props) => {
     </>
   );
 };
+

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -191,7 +191,7 @@ const AgeAndGenderRenderer = ({ user }: Props) => {
       <span>/&nbsp;</span>
       <span>{gender}</span>
       {getGenderVerificationIcon(genderVerificationStatus)}
-      {pronouns && <span>({pronouns})</span>}
+      {pronouns && <span>({pronouns.replace(/\s+/g, "")})</span>}
     </div>
   );
 };

--- a/app/web/features/profile/view/userLabels.tsx
+++ b/app/web/features/profile/view/userLabels.tsx
@@ -189,7 +189,7 @@ const AgeAndGenderRenderer = ({ user }: Props) => {
     >
       <span>{age}</span>
       {getBirthdateVerificationIcon(birthdateVerificationStatus)}
-      <span>/</span>
+      <span>/&nbsp;</span>
       <span>{gender}</span>
       {getGenderVerificationIcon(genderVerificationStatus)}
       {pronouns && <span>({pronouns})</span>}


### PR DESCRIPTION
Closes #4973
Description:
This pull request addresses the following improvements for the profile view:

Fixes the issue of the text looking weird by breaking it into two separate lines in mobile view to remain consistent and readable
Ensures proper top alignment of labels (e.g., "Occupation") with multi-line content.
Fixes inconsistent spacing around the / separator in AgeAndGenderRenderer.
Enhances responsive design to maintain proper spacing and alignment across desktop, mobile, and tablet screens.
Refactors LabelAndText to improve layout and maintainability.
Web frontend checklist

 There are no console warnings when running the app
 Clicked around my changes running locally and it works
 Checked Desktop, Mobile and Tablet screen sizes
 Manually tested changes in the UI and confirmed functionality.
Notes:
No changes were made to the backend.
All changes were tested locally and worked as expected.